### PR TITLE
Adding CSS Class for Series

### DIFF
--- a/templates/series-box.php
+++ b/templates/series-box.php
@@ -1,4 +1,4 @@
-<aside class="wp-post-series-box">
+<aside class="<?php echo $post_series_box_class; ?>">
 	
 	<p class="wp-post-series-name">
 		<?php if ( is_single() && sizeof( $posts_in_series ) > 1 ) : ?>

--- a/wp-post-series.php
+++ b/wp-post-series.php
@@ -254,13 +254,17 @@ class WP_Post_Series {
 			$post_in_series ++;
 		}
 
+		// add the series slug to the post series box class
+		$post_series_box_class = "wp-post-series-box " . "series-". $series->slug;
+
 		ob_start();
 
 		$this->get_template( 'series-box.php', array( 
-			'series'          => $series, 
-			'description'     => $term_description,
-			'posts_in_series' => $posts_in_series,
-			'post_in_series'  => $post_in_series
+			'series'				=> $series, 
+			'description'			=> $term_description,
+			'posts_in_series'		=> $posts_in_series,
+			'post_in_series'		=> $post_in_series,
+			'post_series_box_class'	=> $post_series_box_class
 		) );
 
 		$info_box = ob_get_clean();


### PR DESCRIPTION
We should add in a CSS class for the series to the `<aside class="wp-post-series-box">` that way we can style it differently for each series.

![adding-series-css-class](https://f.cloud.github.com/assets/1065372/1827783/d0283d96-7240-11e3-9edc-0401dd3e8cb9.png)
