### PR TITLE
Show description of series even if the number of posts == 1

### DIFF
--- a/templates/series-box.php
+++ b/templates/series-box.php
@@ -24,7 +24,9 @@
 				<?php endforeach; ?>
 			</ol>
 		</nav>
+	<?php endif; ?>
 
+	<?php if ( is_single() ) : ?>
 		<?php if ( $description ) : ?>
 			<div class="wp-post-series-description"><?php echo wpautop( wptexturize( $description ) ); ?></div>
 		<?php endif; ?>


### PR DESCRIPTION
Currently, the series description isn't shown if the number of posts in the series is equal to < 2. (For example when you've only authored the first post in a series).
