### PR TITLE
Remove the listing with numbers

### DIFF
--- a/templates/series-box.php
+++ b/templates/series-box.php
@@ -13,7 +13,7 @@
 	<?php if ( is_single() && sizeof( $posts_in_series ) > 1 ) : ?>
 
 		<nav class="wp-post-series-nav">
-			<ol>
+			<ul>
 				<?php foreach ( $posts_in_series as $key => $post_id ) : ?>
 					<li>
 						<?php if ( ! is_single( $post_id ) && 'publish' === get_post_status( $post_id ) ) echo '<a href="' . get_permalink( $post_id ) . '">'; ?>
@@ -21,7 +21,7 @@
 						<?php if ( ! is_single( $post_id ) && 'publish' === get_post_status( $post_id ) ) echo '</a>'; ?>
 					</li>
 				<?php endforeach; ?>
-			</ol>
+			</ul>
 		</nav>
 	<?php endif; ?>
 


### PR DESCRIPTION
I think it's a better idea to use 
```HTML
    <ul> 
```
instead of 
```HTML
    <ol> 
```
in order to remove that annoying numbered lists. I think every blogger is using post titles like "Part 1, Part 2, ...) in his series, so the numbered listing is obsolete.