### PR TITLE
Update wp-post-series.php

### DIFF
--- a/wp-post-series.php
+++ b/wp-post-series.php
@@ -216,7 +216,7 @@ class WP_Post_Series {
 	public function add_series_to_content( $content ) {
 		global $post;
 
-		if ( 'post' !== $post->post_type || ! is_main_query() ) {
+		if ( ! is_main_query() || 'post' !== $post->post_type ) {
 			return $content;
 		}
 


### PR DESCRIPTION
Switch of the conditions in the test on line #219 to avoid evaluating $post in situation where it is unset.
Removes a PHP Notice:
[09-Jan-2018 18:09:35 UTC] PHP Notice:  Trying to get property of non-object in (...)\wp-content\plugins\wp-post-series\wp-post-series.php on line 219