### PR TITLE
Limit scripts to blog pages

### DIFF
--- a/wp-post-series.php
+++ b/wp-post-series.php
@@ -348,8 +348,11 @@ class WP_Post_Series {
 	 * @return void
 	 */
 	public function frontend_scripts() {
-		wp_register_script( 'wp-post-series', WP_POST_SERIES_PLUGIN_URL . '/assets/js/post-series.js', array( 'jquery' ), WP_POST_SERIES_VERSION, true );
-		wp_enqueue_style( 'wp-post-series-frontend', WP_POST_SERIES_PLUGIN_URL . '/assets/css/post-series.css' );
+		if ( is_singular('post') || is_home() ) {
+		// enqueue specific scripts for blog homepage and single posts of post type post
+			  wp_register_script( 'wp-post-series', WP_POST_SERIES_PLUGIN_URL . '/assets/js/post-series.js', array( 'jquery' ), WP_POST_SERIES_VERSION, true );
+			  wp_enqueue_style( 'wp-post-series-frontend', WP_POST_SERIES_PLUGIN_URL . '/assets/css/post-series.css' );
+		}
 	}
 }
 


### PR DESCRIPTION
Quick patch to restrict script output to only the blog & blog archive/overview pages. Otherwise script is outut to every page on the site.